### PR TITLE
fix: mediafile.html failed to list dir when "'" in path

### DIFF
--- a/web/templates/rename/mediafile.html
+++ b/web/templates/rename/mediafile.html
@@ -213,7 +213,7 @@
   // 文件区刷新硬链接标记
   function refresh_hardlink_mark(folder){
     // 获取文件夹路径的MD5找到目录树节点
-    let node = $(`#mediafile_tree a[rel='${folder}']`);
+    let node = $(`#mediafile_tree a[rel='${folder.replaceAll("'", "\\'")}']`);
     let locating = false;
     let mark = $("#mediafile_hardlink_mark");
     // 解绑所有事件


### PR DESCRIPTION
修复当文件夹路径中包含单引号时引发报错导致无法列举文件夹内容