### PR TITLE
优化搜索结果的过滤条件顺序

### DIFF
--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -63,16 +63,6 @@
                     {% endfor %}
                   </div>
                   {% endif %}
-                  <div class="subheader mb-2 mt-3">站点</div>
-                  <div class="form-selectgroup form-selectgroup-pills">
-                    {% for filter_site in Item.filter.site %}
-                    <label class="form-selectgroup-item">
-                      <input type="checkbox" name="filter_site" value="{{ filter_site }}" class="form-selectgroup-input"
-                        onclick="filter_medias(this, '{{ Item.key }}')">
-                      <span class="form-selectgroup-label">{{ filter_site }}</span>
-                    </label>
-                    {% endfor %}
-                  </div>
                   <div class="subheader mb-2 mt-3">分辨率</div>
                   <div class="form-selectgroup form-selectgroup-pills">
                     {% for filter_respix in Item.filter.respix %}
@@ -80,26 +70,6 @@
                       <input type="checkbox" name="filter_respix" value="{{ filter_respix }}" class="form-selectgroup-input"
                         onclick="filter_medias(this, '{{ Item.key }}', true)">
                       <span class="form-selectgroup-label">{{ filter_respix }}</span>
-                    </label>
-                    {% endfor %}
-                  </div>
-                  <div class="subheader mb-2 mt-3">制作组</div>
-                  <div class="form-selectgroup form-selectgroup-pills">
-                    {% for filter_releasegroup in Item.filter.releasegroup %}
-                    <label class="form-selectgroup-item">
-                      <input type="checkbox" name="filter_releasegroup" value="{{ filter_releasegroup }}" class="form-selectgroup-input"
-                        onclick="filter_medias(this, '{{ Item.key }}', true)">
-                      <span class="form-selectgroup-label filter_releasegroup_span">{{ filter_releasegroup }}</span>
-                    </label>
-                    {% endfor %}
-                  </div>
-                  <div class="subheader mb-2 mt-2">促销</div>
-                  <div class="form-selectgroup form-selectgroup-pills">
-                    {% for filter_free in Item.filter.free %}
-                    <label class="form-selectgroup-item">
-                      <input type="checkbox" name="filter_free" value="{{ filter_free.value }}" class="form-selectgroup-input"
-                        onclick="filter_medias(this, '{{ Item.key }}')">
-                      <span class="form-selectgroup-label">{{ filter_free.name }}</span>
                     </label>
                     {% endfor %}
                   </div>
@@ -115,6 +85,36 @@
                     {% endfor %}
                   </div>
                   {% endif %}
+                  <div class="subheader mb-2 mt-2">促销</div>
+                  <div class="form-selectgroup form-selectgroup-pills">
+                    {% for filter_free in Item.filter.free %}
+                    <label class="form-selectgroup-item">
+                      <input type="checkbox" name="filter_free" value="{{ filter_free.value }}" class="form-selectgroup-input"
+                        onclick="filter_medias(this, '{{ Item.key }}')">
+                      <span class="form-selectgroup-label">{{ filter_free.name }}</span>
+                    </label>
+                    {% endfor %}
+                  </div>
+                  <div class="subheader mb-2 mt-3">制作组</div>
+                  <div class="form-selectgroup form-selectgroup-pills">
+                    {% for filter_releasegroup in Item.filter.releasegroup %}
+                    <label class="form-selectgroup-item">
+                      <input type="checkbox" name="filter_releasegroup" value="{{ filter_releasegroup }}" class="form-selectgroup-input"
+                        onclick="filter_medias(this, '{{ Item.key }}', true)">
+                      <span class="form-selectgroup-label filter_releasegroup_span">{{ filter_releasegroup }}</span>
+                    </label>
+                    {% endfor %}
+                  </div>
+                  <div class="subheader mb-2 mt-3">站点</div>
+                  <div class="form-selectgroup form-selectgroup-pills">
+                    {% for filter_site in Item.filter.site %}
+                    <label class="form-selectgroup-item">
+                      <input type="checkbox" name="filter_site" value="{{ filter_site }}" class="form-selectgroup-input"
+                        onclick="filter_medias(this, '{{ Item.key }}')">
+                      <span class="form-selectgroup-label">{{ filter_site }}</span>
+                    </label>
+                    {% endfor %}
+                  </div>
                   <div class="mt-3">
                     <button class="btn w-100" onclick="reset_filter(this, '{{ Item.key }}')">
                       重置
@@ -340,16 +340,6 @@
               {% endfor %}
             </div>
             {% endif %}
-            <div class="subheader mb-2 mt-3">站点</div>
-            <div class="form-selectgroup form-selectgroup-pills">
-              {% for filter_site in Item.filter.site %}
-              <label class="form-selectgroup-item">
-                <input type="checkbox" name="filter_site" value="{{ filter_site }}" class="form-selectgroup-input"
-                  onclick="filter_medias(this, '{{ Item.key }}', true)">
-                <span class="form-selectgroup-label">{{ filter_site }}</span>
-              </label>
-              {% endfor %}
-            </div>
             <div class="subheader mb-2 mt-3">分辨率</div>
             <div class="form-selectgroup form-selectgroup-pills">
               {% for filter_respix in Item.filter.respix %}
@@ -357,26 +347,6 @@
                 <input type="checkbox" name="filter_respix" value="{{ filter_respix }}" class="form-selectgroup-input"
                   onclick="filter_medias(this, '{{ Item.key }}', true)">
                 <span class="form-selectgroup-label">{{ filter_respix }}</span>
-              </label>
-              {% endfor %}
-            </div>
-            <div class="subheader mb-2 mt-3">制作组</div>
-            <div class="form-selectgroup form-selectgroup-pills">
-              {% for filter_releasegroup in Item.filter.releasegroup %}
-              <label class="form-selectgroup-item">
-                <input type="checkbox" name="filter_releasegroup" value="{{ filter_releasegroup }}" class="form-selectgroup-input"
-                  onclick="filter_medias(this, '{{ Item.key }}', true)">
-                <span class="form-selectgroup-label filter_releasegroup_span">{{ filter_releasegroup }}</span>
-              </label>
-              {% endfor %}
-            </div>
-            <div class="subheader mb-2 mt-2">促销</div>
-            <div class="form-selectgroup form-selectgroup-pills">
-              {% for filter_free in Item.filter.free %}
-              <label class="form-selectgroup-item">
-                <input type="checkbox" name="filter_free" value="{{ filter_free.value }}" class="form-selectgroup-input"
-                  onclick="filter_medias(this, '{{ Item.key }}', true)">
-                <span class="form-selectgroup-label">{{ filter_free.name }}</span>
               </label>
               {% endfor %}
             </div>
@@ -392,6 +362,36 @@
               {% endfor %}
             </div>
             {% endif %}
+            <div class="subheader mb-2 mt-2">促销</div>
+            <div class="form-selectgroup form-selectgroup-pills">
+              {% for filter_free in Item.filter.free %}
+              <label class="form-selectgroup-item">
+                <input type="checkbox" name="filter_free" value="{{ filter_free.value }}" class="form-selectgroup-input"
+                  onclick="filter_medias(this, '{{ Item.key }}', true)">
+                <span class="form-selectgroup-label">{{ filter_free.name }}</span>
+              </label>
+              {% endfor %}
+            </div>
+            <div class="subheader mb-2 mt-3">制作组</div>
+            <div class="form-selectgroup form-selectgroup-pills">
+              {% for filter_releasegroup in Item.filter.releasegroup %}
+              <label class="form-selectgroup-item">
+                <input type="checkbox" name="filter_releasegroup" value="{{ filter_releasegroup }}" class="form-selectgroup-input"
+                  onclick="filter_medias(this, '{{ Item.key }}', true)">
+                <span class="form-selectgroup-label filter_releasegroup_span">{{ filter_releasegroup }}</span>
+              </label>
+              {% endfor %}
+            </div>
+            <div class="subheader mb-2 mt-3">站点</div>
+            <div class="form-selectgroup form-selectgroup-pills">
+              {% for filter_site in Item.filter.site %}
+              <label class="form-selectgroup-item">
+                <input type="checkbox" name="filter_site" value="{{ filter_site }}" class="form-selectgroup-input"
+                  onclick="filter_medias(this, '{{ Item.key }}', true)">
+                <span class="form-selectgroup-label">{{ filter_site }}</span>
+              </label>
+              {% endfor %}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
在实际使用中添加站点较多，搜索结果较多时，站点和制作组的列表会很长，从而影响其他选项的筛选效率，而很少需要筛选这两项

将过滤条件顺序调整为
季->分辨率->视频编码->促销->制作组->站点

由于仅调整html代码以及我在Windows搭建运行环境失败，仅在现有部署的项目中通过浏览器简单调试，请验证后合并此PR